### PR TITLE
Add MutationObserver to header to fix the z-index

### DIFF
--- a/resources/helpers.js
+++ b/resources/helpers.js
@@ -52,6 +52,8 @@ const waitForElementId = (id, vueComponent, store, num = 200) => {
   }, 10);
 };
 
+const hasElement = className => document.getElementsByClassName(className).length > 0;
+
 const waitForElementClass = (className, vueComponent, store, num = 200) => {
   const el = document.getElementsByClassName(className);
   if (el.length === 1) {
@@ -75,6 +77,7 @@ export {
   isSmallViewport,
   isPhoneViewport,
   constants,
+  hasElement,
   waitForElementId,
   waitForElementIdCb,
   waitForElementClass

--- a/src/app/Header/index.vue
+++ b/src/app/Header/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="b()">
+  <div :class="b({ 'bg': bgShown })">
     <div class="mx-developer__row">
       <button :class="b('hamburger')" type="button" @click.stop.prevent="menu">
         <span :class="b('hamburger-box')">
@@ -14,6 +14,7 @@
 </template>
 <script>
 import Vue from 'vue';
+import { mapGetters } from 'vuex';
 import { ResizeObserver } from 'Resources/vendor/vue-resize';
 import { isSmallViewport, isPhoneViewport } from 'Resources/helpers';
 import NavBar from './Navbar.vue';
@@ -34,6 +35,11 @@ export default {
     NavBar,
     'resize-observer': ResizeObserver,
     'notification': NotificationBar
+  },
+  computed: {
+    ...mapGetters([
+        'bgShown'
+    ])
   },
   methods: {
     menu() {

--- a/src/app/store/getters.js
+++ b/src/app/store/getters.js
@@ -1,5 +1,6 @@
 export default {
   profile: state => state.profile,
   loaded: state => state.loaded,
-  messageStatus: state => state.messageStatus
+  messageStatus: state => state.messageStatus,
+  bgShown: state => state.bgShown
 };

--- a/src/app/store/index.js
+++ b/src/app/store/index.js
@@ -1,6 +1,10 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
 
+import Observer from 'mutation-observer';
+import debounce from 'tiny-debounce';
+import {hasElement} from 'Resources/helpers';
+
 Vue.use(Vuex);
 
 import state from './state';
@@ -13,6 +17,21 @@ const store = new Vuex.Store({
   actions,
   mutations,
   getters
+});
+
+const checkForMxBgs = () => {
+  store.commit('bgShown', hasElement('mx-underlay'));
+};
+
+window._bgObserver = new Observer(debounce(checkForMxBgs, 100));
+
+window._bgObserver.observe(document, {
+  subtree: true,
+  childList: true,
+  attributes: false,
+  characterData: false,
+  attributeOldValue: false,
+  characterDataOldValue: false
 });
 
 export default store;

--- a/src/app/store/mutations.js
+++ b/src/app/store/mutations.js
@@ -7,5 +7,8 @@ export default {
   },
   messageStatus(state, mut) {
     state.messageStatus = mut;
+  },
+  bgShown(state, mut) {
+    state.bgShown = mut;
   }
 };

--- a/src/app/store/state.js
+++ b/src/app/store/state.js
@@ -2,5 +2,6 @@ export default {
   profile: false,
   loaded: false,
   messageStatus: false,
-  isPartner: false
+  isPartner: false,
+  bgShown: false
 };

--- a/src/sass/_header.scss
+++ b/src/sass/_header.scss
@@ -19,4 +19,7 @@
   position: relative;
   z-index: 1000;
   width: 100%;
+  @include modifier('bg') {
+    z-index: 99;
+  }
 }


### PR DESCRIPTION
When Mendix shows modals, these have a z-index of 100+. The header/footer has a standard z-index of 1000 to make sure it's always visible. By adding a Mutation observer we check for elements with class '.mx-underlay'. If so, we add a modifier that will set the z-index to 99, temporary